### PR TITLE
Use scale rather than opacity to indicate duplicates

### DIFF
--- a/themes/crossword/assets/sass/components/_leaderboard-table.scss
+++ b/themes/crossword/assets/sass/components/_leaderboard-table.scss
@@ -46,7 +46,7 @@
 
 // Leaderboard table award element, "duplicate" modifier
 .leaderboard-table__award--duplicate {
-	opacity: 0.3;
+	transform: scale(0.69);
 }
 
 // Leaderboard table award icon element


### PR DESCRIPTION
Because awards should be like Joel's clues: opaque

![Screenshot 2021-07-27 at 13 17 27](https://user-images.githubusercontent.com/21795/127152248-e3b8ecbc-7979-4227-a754-80af87fbddd3.png)
